### PR TITLE
Fix missed geometry change events

### DIFF
--- a/contents/code/tile.js
+++ b/contents/code/tile.js
@@ -202,12 +202,6 @@ Tile.prototype.setClientGeometry = function(client) {
             print("Wrong tile called");
             return;
         }
-        // Don't resize when we aren't the current desktop
-        // or on all desktops
-        if (this._currentDesktop != workspace.currentDesktop
-            && this._currentDesktop != -1) {
-            return;
-        }
         // These two should never be reached
         if (client.deleted) {
             return;

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -58,8 +58,6 @@ Item {
         repeat: false
         interval: 1
         onTriggered: tiling.tiles.updateGeometry();
-        property variant tile
-        property variant client
     }
 
 }


### PR DESCRIPTION
KWin sometimes decides to update geometry of several/all clients simultaneously. Our timer-based asynchronous handler needs to be ready for that. It also needs to handle geometry changes happening
to clients outside of the current desktop, because some effects such as Desktop Grid display badly damaged layouts if it doesn't.

Fixes #135 