### PR TITLE
Allow for moving clients between screens

### DIFF
--- a/contents/code/tile.js
+++ b/contents/code/tile.js
@@ -329,6 +329,16 @@ Tile.prototype.onClientDesktopChanged = function(client) {
     }
 };
 
+Tile.prototype.onClientScreenChanged = function(client) {
+    try {
+        var oldScreen = this._currentScreen;
+        this._currentScreen = client.screen;
+        this.screenChanged.emit(oldScreen, this._currentScreen);
+    } catch(err) {
+        print(err, "in Tile.onClientScreenChanged");
+    }
+};
+
 Tile.prototype.onClientStartUserMovedResized = function(client) {
     // Let client stay above the other tilers so the user sees the move
     client.keepBelow = false;
@@ -421,3 +431,6 @@ Tile.prototype.hasClient = function(client) {
     return (this.clients.indexOf(client) > -1);
 };
 
+Tile.prototype.getDesktop = function() {
+    return this._currentDesktop;
+}

--- a/contents/code/tilelist.js
+++ b/contents/code/tilelist.js
@@ -187,6 +187,12 @@ TileList.prototype.connectSignals = function(client) {
             tile.onClientDesktopChanged(client);
         }
     });
+    client.screenChanged.connect(function() {
+        var tile = getTile(client);
+        if (tile != null) {
+            tile.onClientScreenChanged(client);
+        }
+    });
     client.clientMinimized.connect(function(client) {
         try {
             self.untileClient(client);

--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -785,14 +785,18 @@ TilingManager.prototype._onScreenResized = function(screen) {
 };
 
 TilingManager.prototype._onTileScreenChanged = function(tile, oldScreen, newScreen) {
+    if (oldScreen == newScreen) {
+        return;
+    }
     // If a tile is moved by the user, screen changes are handled in the move
     // callbacks below
     if (this._moving) {
         return;
     }
     // Use tile desktop for the onAllDesktops case
-    var oldLayouts = this._getLayouts(tile.desktop, oldScreen);
-    var newLayouts = this._getLayouts(tile.desktop, newScreen);
+    var desktop = tile.getDesktop();
+    var oldLayouts = this._getLayouts(desktop, oldScreen);
+    var newLayouts = this._getLayouts(desktop, newScreen);
     this._changeTileLayouts(tile, oldLayouts, newLayouts);
     };
 


### PR DESCRIPTION
Fixes #104

@faho If you only use one display and you want to test multiscreen, you can create a virtual screen like this:
```
xrandr --newmode "1624x768_60.00"  101.25  1624 1704 1872 2120  768 771 781 798 -hsync +vsync
xrandr --addmode VIRTUAL1 1624x768_60.00
xrandr --output VIRTUAL1 --mode 1624x768_60.00
x11vnc -display :0 -clip xinerama1 -usepw -xrandr -forever -nonc -noxdamage -repeat -multiptr
```
and connect to it from a VNC client on your smart phone. If you want/need different aspect ratio for your display, you can generate custom modeline using `cvt` command.