### PR TITLE
Add some simple management of virtual desktops

### DIFF
--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -1075,6 +1075,16 @@ TilingManager.prototype._removeEmptyDesktops = function() {
     for (var i = this.desktopCount; i > 1; i--) {
         if (this._isDesktopEmpty(i)) {
             workspace.desktops -= 1;
+            if (!workspace.activeClient) {
+                var master = this._getMaster(this._currentScreen, this._currentDesktop);
+                if (master) {
+                    var client = master.getActiveClient();
+                    if (!client) {
+                        client = master.clients[0];
+                    }
+                    workspace.activeClient = client;
+                }
+            }
         } else {
             break;
         }

--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -100,6 +100,8 @@ function TilingManager(timer) {
      */
     this.layoutChanged = new Signal();
 
+    this._compacting = false;
+
     // Read layout configuration
     // Format: desktop:layoutname[,...]
     // Negative desktop number deactivates tiling
@@ -185,6 +187,11 @@ function TilingManager(timer) {
     });
     workspace.currentDesktopChanged.connect(function() {
         self._onCurrentDesktopChanged();
+    });
+    workspace.clientRemoved.connect(function(client) {
+        if (KWin.readConfig("removeEmptyDesktops", false)) {
+            self._removeEmptyDesktops();
+        }
     });
     // Register keyboard shortcuts
     // KWin versions before 5.8.3 do not have this and will crash if we try to call it
@@ -829,7 +836,7 @@ TilingManager.prototype._onTileScreenChanged = function(tile, oldScreen, newScre
 
 TilingManager.prototype._onTileDesktopChanged = function(tile, oldDesktop, newDesktop) {
         try {
-            if (oldDesktop == newDesktop) {
+            if (oldDesktop == newDesktop || this._compacting) {
                 return;
             }
             var client = tile.clients[0];
@@ -1017,4 +1024,59 @@ TilingManager.prototype._isDesktopEmpty = function(desktop) {
         }
     }
     return empty;
+};
+
+TilingManager.prototype._compactDesktops = function() {
+    this._compacting = true;
+    for (var destination = 1; destination < this.desktopCount; destination++) {
+        if (!this._isDesktopEmpty(destination)) {
+            continue;
+        }
+
+        for (var source = destination + 1; source <= this.desktopCount; source++) {
+            if (this._isDesktopEmpty(source)) {
+                continue;
+            }
+            console.log("moving from to ", source, destination);
+            var i;
+            for (i = 0; i < this.layouts[destination - 1].length; i++) {
+                this.layouts[source - 1][i].deactivate();
+                this.layouts[destination - 1][i].deactivate();
+                var oldLayout = this.layouts[destination - 1][i];
+                this.layouts[destination - 1][i] = this.layouts[source - 1][i];
+                this.layouts[source - 1][i] = oldLayout;
+                this.layouts[destination - 1][i].desktop = destination;
+                this.layouts[source - 1][i].desktop = source;
+            }
+            var clients = workspace.clientList();
+            for (var i = 0; i < clients.length; i++) {
+                var cl = clients[i];
+                if (!cl.onAllDesktops && cl.desktop == source) {
+                    cl.desktop = destination;
+                }
+            }
+            for (i = 0; i < this.layouts[destination - 1].length; i++) {
+                this.layouts[source - 1][i].activate();
+                this.layouts[destination - 1][i].activate();
+            }
+            break;
+        }
+    }
+    this._compacting = false;
+}
+
+TilingManager.prototype._removeEmptyDesktops = function() {
+    var clients = workspace.clientList();
+
+    this._compactDesktops();
+
+    // Desktop 0 is a special desktop for unmapped clients
+    // Desktop 1 is not a good candidate for removal
+    for (var i = this.desktopCount; i > 1; i--) {
+        if (this._isDesktopEmpty(i)) {
+            workspace.desktops -= 1;
+        } else {
+            break;
+        }
+    }
 };

--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -575,6 +575,37 @@ function TilingManager(timer) {
                                       print(err, "in i3-layout-set-normal-mode");
                                   }
                               });
+        KWin.registerShortcut("TILING: Move Window To New Desktop",
+                              "Move Window To New Desktop",
+                              "Meta+Shift+D",
+                              function() {
+                                  try {
+                                      var client = workspace.activeClient;
+                                      if (client != null) {
+                                          var desktop = 0;
+                                          // find first empty desktop
+                                          for (var i = 1; i <= self.desktopCount; i++) {
+                                              if (self._isDesktopEmpty(i)) {
+                                                  desktop = i;
+                                                  break;
+                                              }
+                                          }
+                                          // if there is none, create a new one
+                                          if (desktop == 0 && self.desktopCount < 20) {
+                                              workspace.desktops += 1;
+                                              desktop = self.desktopCount;
+                                          }
+                                          // move the client and activate the desktop
+                                          if (desktop > 0) {
+                                              client.desktop = desktop;
+                                              workspace.currentDesktop = desktop;
+                                              workspace.activeClient = client;
+                                          }
+                                      }
+                                  } catch(err) {
+                                      print(err, "in move-window-to-new-desktop");
+                                  }
+                              });
     }
     // registerUserActionsMenu(function(client) {
     //     return {
@@ -974,4 +1005,16 @@ TilingManager.prototype._getLayouts = function(desktop, screen) {
         }
     }
     return null;
+};
+
+TilingManager.prototype._isDesktopEmpty = function(desktop) {
+    var clients = workspace.clientList();
+    var empty = true;
+    for (var i = 0; i < clients.length; i++) {
+        if (!clients[i].onAllDesktops && clients[i].desktop == desktop) {
+            empty = false;
+            break;
+        }
+    }
+    return empty;
 };

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -65,5 +65,9 @@
 		  <label>Where new tiles should open</label>
 		  <default>0</default>
 		</entry>
+		<entry name="removeEmptyDesktops" type="bool">
+		  <label>Remove empty desktops</label>
+		  <default>false</default>
+		</entry>
     </group>
 </kcfg>

--- a/contents/ui/config.ui
+++ b/contents/ui/config.ui
@@ -75,16 +75,26 @@
         </widget>
        </item>
        <item row="6" column="0">
+        <widget class="QCheckBox" name="kcfg_removeEmptyDesktops">
+         <property name="text">
+          <string>Remove empty desktops</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Placement method</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLineEdit" name="kcfg_layouts"/>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QComboBox" name="kcfg_placement">
          <item>
           <property name="text">


### PR DESCRIPTION
This is a follow-up to abandoned #131.

- adds a keyboard shortcut which moves the current client to the first empty desktop or to a new virtual desktop if there's no an empty one
- introduces automatic (optional, default off) removal of empty desktops

Edit: @faho: Now you can reject it as a whole ;)