### PR TITLE
Move tiles between screens

### DIFF
--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -1027,6 +1027,13 @@ TilingManager.prototype._moveTile = function(direction) {
     var nextTile = layout.getTile(x, y);
     if (nextTile != null) {
         layout.swapTiles(activeTile, nextTile);
+    } else {
+        // No tile to swap. Move to next screen in direction
+        var targetScreen = util.nextScreenInDirection(this._currentScreen, desktop, direction);
+        if (targetScreen != null) {
+            var targetRect = workspace.clientArea(KWin.ScreenArea, targetScreen, desktop);
+            client.geometry = targetRect;
+        }
     }
 };
 

--- a/contents/code/util.js
+++ b/contents/code/util.js
@@ -183,9 +183,21 @@ util.assertRectInScreen = function(rect, screenRectangle) {
 util.nextScreenInDirection = function(curScreen, desktop, direction) {
     var curScreenRect = workspace.clientArea(KWin.ScreenArea, curScreen, desktop);
     var targetScreen = null;
-    // choose this small enough to not jump to wrong screens
-    // and big enough to skip panels
-    var minDist = 200;
+
+    // Limit jump distance
+    switch (direction) {
+        case Direction.Left:
+        case Direction.Right:
+            var minDist = curScreenRect.width / 2;
+            break;
+        case Direction.Up:
+        case Direction.Down:
+            var minDist = curScreenRect.height / 2;
+            break;
+        default:
+            print("Wrong direction in util.nextScreenInDirection");
+            return;
+    }
 
     // assumes a fully horizontal or vertical screen setup
     for (var i=0; i<workspace.numScreens; i++) {
@@ -204,9 +216,6 @@ util.nextScreenInDirection = function(curScreen, desktop, direction) {
             case Direction.Down:
                 var dist = Math.abs(util.getB(curScreenRect) - screenRect.y);
                 break;
-            default:
-                print("Wrong direction in util.nextScreenInDirection");
-                return;
         }
 
         if (dist < minDist) {

--- a/contents/code/util.js
+++ b/contents/code/util.js
@@ -176,8 +176,8 @@ util.assertRectInScreen = function(rect, screenRectangle) {
 };
 
 /**
- * This is not completely trivial since clientArea reports screen areas
- * without panel areas. I know of no way to get the full screen geometry.
+ * workspace.clientArea leaves holes for panels.
+ * Also there could be gaps between screens.
  * Therefore I do a search for the screen with minimal distance in given direction.
  */
 util.nextScreenInDirection = function(curScreen, desktop, direction) {
@@ -187,32 +187,32 @@ util.nextScreenInDirection = function(curScreen, desktop, direction) {
     // and big enough to skip panels
     var minDist = 200;
 
-    // assumes a fully horizontal screen setup
-    if (direction == Direction.Left) {
-        for (var i=0; i<workspace.numScreens; i++) {
-            var screenRect = workspace.clientArea(KWin.ScreenArea, i, desktop);
+    // assumes a fully horizontal or vertical screen setup
+    for (var i=0; i<workspace.numScreens; i++) {
+        var screenRect = workspace.clientArea(KWin.ScreenArea, i, desktop);
 
-            var dist = Math.abs(curScreenRect.x - util.getR(screenRect));
-            if (dist < minDist) {
-                targetScreen = i;
-                minDist = dist;
-            }
+        switch (direction) {
+            case Direction.Left:
+                var dist = Math.abs(curScreenRect.x - util.getR(screenRect));
+                break;
+            case Direction.Right:
+                var dist = Math.abs(util.getR(curScreenRect) - screenRect.x);
+                break;
+            case Direction.Up:
+                var dist = Math.abs(curScreenRect.y - util.getB(screenRect));
+                break;
+            case Direction.Down:
+                var dist = Math.abs(util.getB(curScreenRect) - screenRect.y);
+                break;
+            default:
+                print("Wrong direction in util.nextScreenInDirection");
+                return;
         }
-    } else if (direction == Direction.Right) {
-        for (var i=0; i<workspace.numScreens; i++) {
-            var screenRect = workspace.clientArea(KWin.ScreenArea, i, desktop);
 
-            var dist = Math.abs(util.getR(curScreenRect) - screenRect.x);
-            if (dist < minDist) {
-                targetScreen = i;
-                minDist = dist;
-            }
+        if (dist < minDist) {
+            targetScreen = i;
+            minDist = dist;
         }
-        // } else if (direction == Direction.Up) {
-        // } else if (direction == Direction.Down) {
-    } else {
-        print("Wrong direction in util.nextScreenInDirection");
-        return;
     }
 
     return targetScreen;

--- a/contents/code/util.js
+++ b/contents/code/util.js
@@ -175,6 +175,49 @@ util.assertRectInScreen = function(rect, screenRectangle) {
                     util.getB(rect) <= util.getB(screenRectangle), "Rectangle not in screen");
 };
 
+/**
+ * This is not completely trivial since clientArea reports screen areas
+ * without panel areas. I know of no way to get the full screen geometry.
+ * Therefore I do a search for the screen with minimal distance in given direction.
+ */
+util.nextScreenInDirection = function(curScreen, desktop, direction) {
+    var curScreenRect = workspace.clientArea(KWin.ScreenArea, curScreen, desktop);
+    var targetScreen = null;
+    // choose this small enough to not jump to wrong screens
+    // and big enough to skip panels
+    var minDist = 200;
+
+    // assumes a fully horizontal screen setup
+    if (direction == Direction.Left) {
+        for (var i=0; i<workspace.numScreens; i++) {
+            var screenRect = workspace.clientArea(KWin.ScreenArea, i, desktop);
+
+            var dist = Math.abs(curScreenRect.x - util.getR(screenRect));
+            if (dist < minDist) {
+                targetScreen = i;
+                minDist = dist;
+            }
+        }
+    } else if (direction == Direction.Right) {
+        for (var i=0; i<workspace.numScreens; i++) {
+            var screenRect = workspace.clientArea(KWin.ScreenArea, i, desktop);
+
+            var dist = Math.abs(util.getR(curScreenRect) - screenRect.x);
+            if (dist < minDist) {
+                targetScreen = i;
+                minDist = dist;
+            }
+        }
+        // } else if (direction == Direction.Up) {
+        // } else if (direction == Direction.Down) {
+    } else {
+        print("Wrong direction in util.nextScreenInDirection");
+        return;
+    }
+
+    return targetScreen;
+};
+
 util.middlex = function(rect) {
     return rect.x + (rect.width / 2);
 };


### PR DESCRIPTION
Possible fix for #156.
I tested this with 3 screens oriented horizontally or vertically.
This works for this simple case but behavior could get weird for monitor setups like
```
+----+ +---+
|    | |   |
+----+ +---+
   +-----+
   |     |
   +-----+
```
I don't know a good general solution for such cases but also didn't put much thought into that yet.

Feedback welcome.