### PR TITLE
Fix window gaps being incorrectly applied when a window is being resized

### DIFF
--- a/contents/code/tiling.js
+++ b/contents/code/tiling.js
@@ -256,7 +256,11 @@ Tiling.prototype.resizeTile = function(tile){
         if (tile != null) {
             var tileIndex = tile.tileIndex;
             var client = tile.clients[0];
-            this.layout.resizeTile(tileIndex, client.geometry);
+            var geometry = Qt.rect(client.geometry.x - this.windowsGapSizeWidth,
+                client.geometry.y - this.windowsGapSizeHeight,
+                client.geometry.width + this.windowsGapSizeWidth * 2,
+                client.geometry.height + this.windowsGapSizeHeight * 2);
+            this.layout.resizeTile(tileIndex, geometry);
             this._updateAllTiles();
         }
     } catch(err) {
@@ -268,7 +272,10 @@ Tiling.prototype.resizeTileTo = function(tile,geometry) {
     try {
         if (tile != null && geometry != null) {
             var tileIndex = tile.tileIndex;
-            var client = tile.clients[0];
+            geometry = Qt.rect(geometry.x - this.windowsGapSizeWidth,
+                geometry.y - this.windowsGapSizeHeight,
+                geometry.width + this.windowsGapSizeWidth * 2,
+                geometry.height + this.windowsGapSizeHeight * 2);
             this.layout.resizeTile(tileIndex, geometry);
             this._updateAllTiles();
         }


### PR DESCRIPTION
Hello!

When I'm resizing a window, (window) gaps around it disappear. It only affects the window being resized, while all other windows around it are positioned correctly.

That is, when the right mouse button is pressed, the window occupies the whole tile (see screenshot), ignoring the window_gap setting. And when the button is released, the gaps finally get applied and the window shrinks. 
So, for example, if you attempt to expand a window by 1px and your window gaps are 16px, the window actually shrinks 15px after you release the button. The bug also affects `Resize Active Window To The X` hotkeys. This is most noticeable when you are using large window gaps.

This PR attempts to fix it, please feel free to point out any mistakes.

![Screenshot_20200104_021352](https://user-images.githubusercontent.com/29466521/71755519-001e8f00-2e9c-11ea-86c6-dfc525d86940.png)
