### PR TITLE
Add shortcuts to switch to each layout

### DIFF
--- a/contents/code/tilingmanager.js
+++ b/contents/code/tilingmanager.js
@@ -213,6 +213,21 @@ function TilingManager(timerResize, timerGeometryChanged) {
     // KWin versions before 5.8.3 do not have this and will crash if we try to call it
     // So just check if the function is available
     if (KWin.registerShortcut) {
+        for(let desiredLayout of self.availableLayouts) {
+            let layoutName = desiredLayout.name.replace("Layout", " Tiling Layout");
+            KWin.registerShortcut("TILING: Switch to " + layoutName,
+                                  "TILING: Switch to " + layoutName,
+                                  "",
+                                  function() {
+                                      var currentLayout = self._getCurrentLayoutType();
+                                      if (desiredLayout.index != currentLayout.index) {
+                                          self._switchLayout(workspace.currentDesktop,
+                                                             workspace.activeScreen,
+                                                             desiredLayout.index);
+                                          self._notifyLayoutChanged();
+                                      }
+                                  });
+        }
         KWin.registerShortcut("TILING: Next Tiling Layout",
                               "TILING: Next Tiling Layout",
                               "Meta+Shift+PgDown",


### PR DESCRIPTION
> Add shortcuts to switch to each layout
>
> When registering keyboard shortcuts, iterate over the `TilingManager.availableLayouts`
> array and register a shortcut to switch to each layout.

This commit adds the option to assign a shortcut to switch directly to any layout type.

For example:
I can assign _GridLayout_ to `Meta+1` and _HalfLayout_ to `Meta+2` so I can directly switch to them, whereas before I had to cycle forward twice (or backward three times) to switch from _GridLayout_ to _HalfLayout_.