### PR TITLE
Ignore Tor Browser by default

### DIFF
--- a/contents/code/ignored.js
+++ b/contents/code/ignored.js
@@ -49,6 +49,7 @@ ignored._ignoredlist = [
     "org.kde.plasma-desktop",
     "org.kde.plasmashell",
     "urxvt",
+    "Tor Browser",
 ]
 
 /**


### PR DESCRIPTION
Part of the philosophy of the Tor Browser is security through obscurity. It is recommended that users do not resize the Tor Browser window so all Tor Browser users look similar to fingerprinting scripts. For this reason, by default the tiling script should not be resizing Tor Browser.

Perhaps there is a better way to do this than ignoring it entirely (?), but I ended up adding it to the exception list in my personal installation.