### PR TITLE
Ignore Ulauncher by default

### DIFF
--- a/contents/code/ignored.js
+++ b/contents/code/ignored.js
@@ -49,6 +49,7 @@ ignored._ignoredlist = [
     "org.kde.plasma-desktop",
     "org.kde.plasmashell",
     "urxvt",
+    "Ulauncher",
 ]
 
 /**


### PR DESCRIPTION
Ulauncher is an application launcher. Its window is a small input field that pops up when its hotkey is pressed. It should not affect window tiling layouts.

I'm not sure what the project philosophy is on adding apps to the ignore list, but at the very least the default behavior was annoying to me for this one.