### PR TITLE
Add Wayland specific exception for Firefox's secondary windows

### DIFF
--- a/contents/code/ignored.js
+++ b/contents/code/ignored.js
@@ -93,7 +93,7 @@ ignored.isIgnored = function(client) {
     // so we check for their captions.
     if (["Firefox — Sharing Indicator"].includes(client.caption)) {
         print("Ignoring client because of firefox workaround", client.caption);
-	return true;
+        return true;
     }
 
     // KFind is annoying. It sets the window type to dialog (which is arguably wrong) and more importantly sets

--- a/contents/code/ignored.js
+++ b/contents/code/ignored.js
@@ -89,6 +89,12 @@ ignored.isIgnored = function(client) {
         return true;
     }
 
+    // HACK: On Wayland, Firefox's secondary windows doesn't have any resourceName
+    if (["Firefox — Sharing Indicator"].includes(client.caption)) {
+        print("Ignoring client because of firefox workaround", client.caption);
+	return true;
+    }
+
     // KFind is annoying. It sets the window type to dialog (which is arguably wrong) and more importantly sets
     // the transient_for property for some bogus "Qt Client Leader Window".
     //

--- a/contents/code/ignored.js
+++ b/contents/code/ignored.js
@@ -90,6 +90,7 @@ ignored.isIgnored = function(client) {
     }
 
     // HACK: On Wayland, Firefox's secondary windows doesn't have any resourceName
+    // so we check for their captions.
     if (["Firefox — Sharing Indicator"].includes(client.caption)) {
         print("Ignoring client because of firefox workaround", client.caption);
 	return true;


### PR DESCRIPTION
Hello all!

This pull request aims to add a Wayland specific exception to Firefox's secondary windows, such as it's Sharing Indicator, which currently is the only exception.

Also for the record, Firefox's Sharing Indicator is a normal window under Wayland, which makes it behave counter-intuitively, if anyone wants to fix this I managed to do it through this Window Rule:
![image](https://user-images.githubusercontent.com/37230465/195764716-13f9c015-61bc-427d-b7f1-2e6caca4bafc.png)
> Position here is set according to my own Display as to make the indicator appear on the top-center side of the screen (With a horizontal resolution of 2560 and an indicator size of 50, 2560 / 2 - 50 = 1230)

Best Regards,
João Pedro Braz
